### PR TITLE
Gracefully handle no iconUrl

### DIFF
--- a/addon/components/smart-banner.js
+++ b/addon/components/smart-banner.js
@@ -20,6 +20,7 @@ export default Ember.Component.extend({
   layout,
 
   classNames: ['ember-smart-banner'],
+  classNameBindings: ['iconUrl:has-icon'],
   // http://discuss.emberjs.com/t/best-practices-accessing-app-config-from-addon-code/7006/16
   config: computed(function() {
     return getOwner(this).resolveRegistration('config:environment').emberSmartBanner;

--- a/addon/templates/components/smart-banner.hbs
+++ b/addon/templates/components/smart-banner.hbs
@@ -1,9 +1,11 @@
 {{#if showBanner}}
   <div class="ember-smart-banner--inner">
     <a href="#" class='ember-smart-banner--close-button' onclick={{action 'closeBanner'}}>&times;</a>
-    <div class="ember-smart-banner--icon">
-      <img src="{{iconUrl}}" alt="App Icon" />
-    </div>
+    {{#if iconUrl}}
+      <div class="ember-smart-banner--icon">
+        <img src="{{iconUrl}}" alt="App Icon" />
+      </div>
+    {{/if}}
     <div class="ember-smart-banner--info">
       <strong class="ember-smart-banner--title">{{title}}</strong>
       <span class="ember-smart-banner--description">{{description}}</span>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('no-icon');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,18 +1,6 @@
 <h1 class='test'>Ember Smart Banner</h1>
-
-<div class="marvel-device iphone6plus black">
-   <div class="top-bar"></div>
-   <div class="sleep"></div>
-   <div class="volume"></div>
-   <div class="camera"></div>
-   <div class="sensor"></div>
-   <div class="speaker"></div>
-   <div class="smart-banner-demo screen">
-      {{smart-banner
-        iOS=true
-        appIdIOS=123
-      }}
-   </div>
-   <div class="home"></div>
-   <div class="bottom-bar"></div>
+<div>
+  {{#link-to 'index'}}Example with icon{{/link-to}}
 </div>
+
+{{outlet}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,7 @@
 <h1 class='test'>Ember Smart Banner</h1>
 <div>
   {{#link-to 'index'}}Example with icon{{/link-to}}
+  {{#link-to 'no-icon'}}Example without icon{{/link-to}}
 </div>
 
 {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,16 @@
+<div class="marvel-device iphone6plus black">
+   <div class="top-bar"></div>
+   <div class="sleep"></div>
+   <div class="volume"></div>
+   <div class="camera"></div>
+   <div class="sensor"></div>
+   <div class="speaker"></div>
+   <div class="smart-banner-demo screen">
+      {{smart-banner
+        iOS=true
+        appIdIOS=123
+      }}
+   </div>
+   <div class="home"></div>
+   <div class="bottom-bar"></div>
+</div>

--- a/tests/dummy/app/templates/no-icon.hbs
+++ b/tests/dummy/app/templates/no-icon.hbs
@@ -1,0 +1,17 @@
+<div class="marvel-device iphone6plus black">
+   <div class="top-bar"></div>
+   <div class="sleep"></div>
+   <div class="volume"></div>
+   <div class="camera"></div>
+   <div class="sensor"></div>
+   <div class="speaker"></div>
+   <div class="smart-banner-demo screen">
+      {{smart-banner
+        iOS=true
+        appIdIOS=123
+        iconUrl=null
+      }}
+   </div>
+   <div class="home"></div>
+   <div class="bottom-bar"></div>
+</div>

--- a/vendor/smart-banner.css
+++ b/vendor/smart-banner.css
@@ -45,13 +45,16 @@
 }
 .ember-smart-banner--info {
   position: absolute;
-  left: 8.95em;
+  left: 4em;
   top: 2.2em;
   width: 44%;
   font-size: 0.7em;
   line-height: 1.2em;
   font-weight: bold;
   color: #000;
+}
+.has-icon .ember-smart-banner--info {
+  left: 8.95em;
 }
 .ember-smart-banner--info strong {
   display: block;


### PR DESCRIPTION
Adds support for no icon. new /no-icon dummy route has an example

![2016-05-18-002212_530x379_scrot](https://cloud.githubusercontent.com/assets/489896/15350560/fb4faf86-1c8e-11e6-82ee-3d2a6badfa0c.png)  
  
  
Was:
![2016-05-18-002527_509x261_scrot](https://cloud.githubusercontent.com/assets/489896/15350579/128d1e4a-1c8f-11e6-956c-5e6ed63c3479.png)
