### PR TITLE
Detect isNaN date lengths

### DIFF
--- a/addon/components/smart-banner.js
+++ b/addon/components/smart-banner.js
@@ -160,11 +160,13 @@ export default Ember.Component.extend({
     return (this.get(firstKey) >= this.get(secondKey));
   },
 
+  // Returns NaN if no localstorage data has been set
   daysSinceClose: computed(function() {
     const timeSinceClosed = new Date() - Date.parse(getDayClosed());
     return Math.floor(timeSinceClosed / (24 * 60 * 60 * 1000)); // Convert ms to days
   }),
 
+  // Returns NaN if no localstorage data has been set
   daysSinceVisit: computed(function() {
     const timeSinceVisited = new Date() - Date.parse(getDayVisited());
     return Math.floor(timeSinceVisited / (24 * 60 * 60 * 1000)); // Convert ms to days

--- a/addon/components/smart-banner.js
+++ b/addon/components/smart-banner.js
@@ -112,13 +112,14 @@ export default Ember.Component.extend({
   openAfterVisit: computed.reads('config.openAfterVisit'),
 
   neverShowAfterClose: computed.equal('openAfterClose', false),
-  recentlyClosed: computed.bool('daysSinceClose'),
+  neverClosed: computedIsNaN('daysSinceClose'),
+  recentlyClosed: computed.not('neverClosed'),
   restrictAfterClose: restrictMacro('openAfterClose'),
 
   neverShowAfterVisit: computed.equal('openAfterVisit', false),
-  recentlyVisited: computed.bool('daysSinceVisit'),
+  neverVisited: computedIsNaN('daysSinceVisit'),
+  recentlyVisited: computed.not('neverVisited'),
   restrictAfterVisit: restrictMacro('openAfterVisit'),
-
 
   afterCloseBool: computed('daysSinceClose', 'openAfterClose', function() {
     const wasRecentlyClosed = this.get('recentlyClosed');
@@ -174,6 +175,12 @@ export default Ember.Component.extend({
 
   //https://github.com/jasny/jquery.smartbanner/blob/master/jquery.smartbanner.js
 });
+
+function computedIsNaN(depKey) {
+  return computed(function() {
+    return isNaN(this.get(depKey));
+  });
+}
 
 function restrictMacro(delayKey) {
   return computed(delayKey, function() {

--- a/tests/integration/components/smart-banner-test.js
+++ b/tests/integration/components/smart-banner-test.js
@@ -1,6 +1,11 @@
 /* global localStorage */
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const {
+  run
+} = Ember;
 
 moduleForComponent('smart-banner', 'Integration | Component | ember smart banner', {
   integration: true
@@ -215,8 +220,10 @@ test('should successfully record click of close button ', function(assert) {
 
   // Click close button and assert that lastDayClosed is stored;
   const smartBanner = this.$();
-  smartBanner.find('.ember-smart-banner--close-button').click();
-  assert.ok(localStorage.getItem('ember-smart-banner.lastDayClosed'), 'click of close button is stored correctly');
+  run(() => {
+    smartBanner.find('.ember-smart-banner--close-button').click();
+    assert.ok(localStorage.getItem('ember-smart-banner.lastDayClosed'), 'click of close button is stored correctly');
+  });
 });
 
 test('should successfully record click of link', function(assert) {
@@ -238,8 +245,10 @@ test('should successfully record click of link', function(assert) {
 
   // Click close button and assert that lastDayClosed is stored;
   const smartBanner = this.$();
-  smartBanner.find('.ember-smart-banner--view-button').click();
-  assert.ok(localStorage.getItem('ember-smart-banner.lastDayVisited'), 'click of link is stored correctly');
+  run(() => {
+    smartBanner.find('.ember-smart-banner--view-button').click();
+    assert.ok(localStorage.getItem('ember-smart-banner.lastDayVisited'), 'click of link is stored correctly');
+  });
 });
 
 test('banner should be open if number of days since the banner was closed is equal to the set duration', function(assert) {
@@ -547,8 +556,10 @@ test('it invokes the provided callback when clicking closed', function(assert) {
   }}`);
 
   const smartBanner = this.$();
-  smartBanner.find('.ember-smart-banner--close-button').click();
-  assert.equal(functionInvoked, true, 'the provded callback was called');
+  run(() => {
+    smartBanner.find('.ember-smart-banner--close-button').click();
+    assert.equal(functionInvoked, true, 'the provded callback was called');
+  });
 });
 
 test('it invokes the provided callback when clicking view', function(assert) {
@@ -575,8 +586,10 @@ test('it invokes the provided callback when clicking view', function(assert) {
   }}`);
 
   const smartBanner = this.$();
-  smartBanner.find('.ember-smart-banner--view-button').click();
-  assert.equal(functionInvoked, true, 'the provded callback was called');
+  run(() => {
+    smartBanner.find('.ember-smart-banner--view-button').click();
+    assert.equal(functionInvoked, true, 'the provded callback was called');
+  });
 });
 
 test('closed today is not the same as never closed', function(assert) {


### PR DESCRIPTION
On the first day of closing the banner, the `daysSinceClose` fields would be 0. That would be converted to `false` by the `computed.bool` property `recentlyClosed`. 

A failing test for this was added to `master`, and this fixes it